### PR TITLE
Deprecated all information pages

### DIFF
--- a/template/ig/chinese-web
+++ b/template/ig/chinese-web
@@ -3,7 +3,7 @@ Welcome to the W3C Chinese Web Interest Group!
 
 请花几分钟浏览并收藏以下页面：
 Please take a few minutes to browse and bookmark this information:
- https://w3c.github.io/Guide/participant/group.html?gid=109611
+ https://www.w3.org/groups/ig/chinese-web/
 
 您现已自动订阅小组成员的邮件列表。可在此查看以往的小组消息：
 You are now subscribed to the group members mailing list. You can look through the archives to see past messages at:

--- a/template/wg/ag
+++ b/template/wg/ag
@@ -50,7 +50,7 @@ If you need accessibility accommodations to participate in the work, please
 let us know, with enough lead time to implement them.
 
 Please take a few minutes to browse and bookmark this information:
-  https://w3c.github.io/Guide/participant/group.html?gid=35422
+  https://www.w3.org/groups/{{ shorttype }}/{{ group.shortname }}/
 
 All participants are required to follow the W3C Code of Ethics and 
 Professional Conduct:

--- a/template/wg/ag
+++ b/template/wg/ag
@@ -1,3 +1,4 @@
+{% set shorttype = 'wg' %}
 Hello - welcome to the Accessibility Guidelines Working Group!
 
 This is a short-introduction email to provide a little information and

--- a/template/wg/media
+++ b/template/wg/media
@@ -1,3 +1,4 @@
+ {% set shorttype = 'wg' %}
 Welcome to the W3C Media Working Group!
 
 You can find more information about our group, including charter, participants list, and publications, here:

--- a/template/wg/media
+++ b/template/wg/media
@@ -8,7 +8,7 @@ The Working Group co-chairs are Chris Needham (BBC) and Marcos Caceres (Apple). 
 
 The Working Group does most of its work on GitHub, with each of our specifications developed in its own repository:
 
-https://www.w3.org/PM/Groups/repositories.html?gid={{ group.id }}
+https://www.w3.org/groups/{{ shorttype }}/{{ group.shortname }}/tools/
 
 We have a monthly teleconference, on the second Tuesday of each month.
 

--- a/template/wg/timed-text
+++ b/template/wg/timed-text
@@ -6,7 +6,7 @@ Please could you send a short introduction to the member-tt@w3.org mailing list,
 
 The Working Group does most of its work on
 Github, with each of our specifications developed in its own repository
-(as listed in https://www.w3.org/PM/Groups/repositories.html?gid={{ group.id }}).
+(as listed in https://www.w3.org/groups/{{ shorttype }}/{{ group.shortname }}/tools/).
 
 If you plan to contribute changes to the specifications by providing
 pull requests, please link your Github and W3C accounts at:
@@ -43,8 +43,6 @@ The group sometimes uses a wiki for managing documents such as
 implementation reports, registries, and ideas. This can be found at:
   https://www.w3.org/wiki/TimedText
 
-https://w3c.github.io/Guide/participant/group.html?gid={{ group.id }}
-is a complete map of useful resources for new participants in this group.
 {{ group._links.homepage.href }} is also a useful resource.
 
 Should you have any question on how to get back up to speed with the

--- a/template/wg/timed-text
+++ b/template/wg/timed-text
@@ -1,3 +1,4 @@
+ {% set shorttype = 'wg' %}
 Welcome to the W3C {{ group.name }}!
 
 As with all W3C work, the https://www.w3.org/Consortium/cepc/ applies to everything we do.

--- a/template/wg/webrtc
+++ b/template/wg/webrtc
@@ -29,7 +29,7 @@ https://w3c.github.io/webrtc-nv-use-cases/ , including the WebRTC Encoded Transf
 The Working Group operates according to the work mode documented at:
   https://github.com/w3c/webrtc-charter/blob/gh-pages/workmode.md
 
-https://w3c.github.io/Guide/participant/group.html?gid={{ group.id }}
+https://www.w3.org/groups/{{ shorttype }}/{{ group.shortname }}/
 is a complete map of useful resources for new participants in this group.
 
 Should you have any question on how to get back up to speed with the

--- a/template/wg/webrtc
+++ b/template/wg/webrtc
@@ -1,3 +1,4 @@
+ {% set shorttype = 'wg' %}
 Welcome to the W3C {{ group.name }}!
 
 The Working Group does most of its work on


### PR DESCRIPTION
List of repositories and other useful links are on our W3C default group pages
