### PR TITLE
fix typo and update chairs list

### DIFF
--- a/template/wg/ag
+++ b/template/wg/ag
@@ -68,7 +68,7 @@ Group, please get in touch with the chairs and staff contacts by email to
 
 Kind regards,
 
-Chuck, Racahel, Alastair
+Rachael, Alastair
 Accessibility Guidelines Working Group chairs
 
 and Kevin


### PR DESCRIPTION
cc @alastc and @rachaelbradley  

(please don't merge without checking with them)

I was in chairs training today and this repo was mentioned. When checking our group's, I noticed a typo in Rachael's name, this fixes that.