### PR TITLE
Updated the grossly outdated VC onboarding template

### DIFF
--- a/template/wg/vc
+++ b/template/wg/vc
@@ -2,23 +2,17 @@ Welcome to the W3C Verifiable Credentials Working Group!
 
 We are delighted to have you join us. Our mission is is to is to make expressing and exchanging credentials that have been verified by a third party easier and more secure on the Web.
 
-Our chairs are Phil Archer (GS1) and Brent Zundel (Yubico). 
+Our chairs are Phil Archer (GS1) and Brent Zundel (Yubico).
 The staff contact is Ivan Herman.
 
 You will find all information on the Working Group on the Group's home page:
 
-  https://www.w3.org/2017/vc/WG/
+  https://www.w3.org/groups/wg/vc/
 
 In particular, you can find:
 
-"getting started" in the Working Group
-  https://www.w3.org/2017/vc/WG/WorkMode/getting-started
-
-Working Group's working modes
-  https://www.w3.org/2017/vc/WG/WorkMode/
-
 meeting schedules and details:
-  https://www.w3.org/2017/vc/WG/Meetings/
+  https://www.w3.org/groups/wg/vc/calendar/
 
 publication status and milestones:
   https://www.w3.org/groups/wg/vc/publications
@@ -26,13 +20,22 @@ publication status and milestones:
 current participants:
   https://www.w3.org/groups/wg/vc/participants?sortaff=1
 
-list of the group repositories on github:
-  https://github.com/topics/vc-wg
+list of the group repositories on GitHub:
+  https://www.w3.org/groups/wg/vc/tools/
+
+Note that the Working Group mostly works through Task Forces:
+  https://www.w3.org/groups/wg/vc/task-forces/
+
+Each task force concentrates on particular subjects within the scope of the Working Group. They have their own
+meeting schedules, GitHub repositories, etc. You are strongly encouraged to join one or several of those task
+forces. At the moment, this requires you to send a mail to Ivan Herman, who will be happy to add you to
+the respective task forces' participant lists.
 
 All participants are required to follow the W3C Code of Conduct:
   https://www.w3.org/policies/code-of-conduct/
 
-Should you have any questions on how to get up to speed with the group, please get in touch with us, e.g., by using the chairs' mailing list:
+Should you have any questions on how to get up to speed with the group, please get in touch with us, e.g.,
+by using the chairs' mailing list:
   group-vc-wg-chairs@w3.org
 
 Phil, Brent, and Ivan

--- a/template/wg/vc
+++ b/template/wg/vc
@@ -20,16 +20,20 @@ publication status and milestones:
 current participants:
   https://www.w3.org/groups/wg/vc/participants?sortaff=1
 
-list of the group repositories on GitHub:
+The Working Group works almost exclusively on GitHub. This means that you should have a GitHub identifier,
+which should also be connected to your W3C account:
+  https://www.w3.org/users/myprofile/connectedaccounts/
+
+Here is the list of the group repositories on GitHub:
   https://www.w3.org/groups/wg/vc/tools/
 
-Note that the Working Group mostly works through Task Forces:
+The Working Group mostly works through Task Forces:
   https://www.w3.org/groups/wg/vc/task-forces/
 
 Each task force concentrates on particular subjects within the scope of the Working Group. They have their own
 meeting schedules, GitHub repositories, etc. You are strongly encouraged to join one or several of those task
-forces. At the moment, this requires you to send a mail to Ivan Herman, who will be happy to add you to
-the respective task forces' participant lists.
+forces. This requires you to send a mail to Ivan Herman, who will be happy to add you to the respective
+task forces' participant lists.
 
 All participants are required to follow the W3C Code of Conduct:
   https://www.w3.org/policies/code-of-conduct/


### PR DESCRIPTION
- Some references used the old WG home page, that is no longer in use
- Added information on task forces, inviting the person to join them.

cc: @w3c-group-98922-chairs